### PR TITLE
Fix processor not applying changes to XMLs with namespaces

### DIFF
--- a/Assets/CsprojLangVersionProcessor/Editor/CsprojLangVersionProcessor.cs
+++ b/Assets/CsprojLangVersionProcessor/Editor/CsprojLangVersionProcessor.cs
@@ -16,7 +16,8 @@ namespace CsprojLangVersionProcessor.Editor
             if (versionString == null) return content;
 
             var doc = XDocument.Parse(content);
-            foreach (var element in doc.Descendants("LangVersion"))
+            var ns = doc.Root!.Name.Namespace;
+            foreach (var element in doc.Descendants(ns + "LangVersion"))
             {
                 element.Value = versionString;
             }


### PR DESCRIPTION
Project files I've been working with use the `http://schemas.microsoft.com/developer/msbuild/2003` namespace - this causes an issue with `Descendants` query, as it checks for the full name, i.e. the one including the element's namespace.

The proposed fix utilizes the `+` operator of the `XNamespace`, which handles both cases. This way, the processor queries for `LangVersion` or `{http://schemas.microsoft.com/developer/msbuild/2003}LangVersion`, depending on the scenario.